### PR TITLE
Support underlying put API

### DIFF
--- a/java/src/main/java/org/rocksdb/RocksDB.java
+++ b/java/src/main/java/org/rocksdb/RocksDB.java
@@ -407,6 +407,21 @@ public class RocksDB extends RocksObject {
   }
 
   /**
+   * Set the database entry for "key" to "value".
+   *
+   * @param key the specified key to be inserted.
+   * @param value the value associated with the specified key.
+   * @param length how many bytes to copy from value to tht database entry.
+   *
+   * @throws RocksDBException thrown if error happens in underlying
+   *    native library.
+   */
+  public void put(final byte[] key, final byte[] value, final int length) 
+      throws RocksDBException {
+    put(nativeHandle_, key, key.length, value, length);
+  }
+
+  /**
    * Set the database entry for "key" to "value" in the specified
    * column family.
    *


### PR DESCRIPTION
It is common practice to pre-allocate arrays so in high write situations you don't need to keep 
creating large array objects. As the current API requires full array, this means an array needs to be 
copied before passing to RocksDB. 

By supporting the underlying C API, an additional memory copy can be avoided leading to
a big saving in GC in high write circumstances.
